### PR TITLE
Add KGPrune: an API and Web application to extract subgraphs from Wikidata to bootstrap new KGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Links and description of Knowledge Graphs Construction Tools
 ## KGC Pipelines
 * [KGCP](http://w3id.org/kgcp/) - "_KG Construction Pipeline_" - A suite of software artifacts to automate the creation of KGs from heterogeneous data sources.
 
+## KG subgraph extractors
+* [KGPrune](https://kgprune.loria.fr/) - An API and Web application for extracting subgraphs of interest from Wikidata based on user-input seed entities, to bootstrap a new KG.
+
 ## KGC Evaluation
 * [KROWN](https://github.com/kg-construct/krown) - A Benchmark for RDF Graph Materialization
 * [Data Sprout](https://www.dfki.uni-kl.de/~mschroeder/demo/datasprout/) - Excel spreadsheet generator for evaluating KG construction.


### PR DESCRIPTION
Dear all, 

I have added to the list KGPrune, a new API and Web application to extract subgraphs of interest from Wikidata based on user-input seed entities. KGPrune starts from these seed entities, and keeps or prunes their neighboring entities to avoid topical drift and extract subgraphs related to the user domains of interest.

I hope this can be of interest for this repository. 

Best,
Pierre